### PR TITLE
Updating docker build action to skip on forks

### DIFF
--- a/.github/workflows/docker-build-fork.yml
+++ b/.github/workflows/docker-build-fork.yml
@@ -1,4 +1,4 @@
-name: Publish in GitHub Package Registry
+name: Docker Build (Fork)
 on:
   pull_request:
 jobs:

--- a/.github/workflows/docker-build-fork.yml
+++ b/.github/workflows/docker-build-fork.yml
@@ -1,0 +1,14 @@
+name: Publish in GitHub Package Registry
+on:
+  pull_request:
+jobs:
+  docker-build-succeeds:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.fork }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Docker Build
+        run: docker build . --no-cache

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   build-and-push-docker-image:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Forks do not have access to secrets and so are unable to build and push to the ghcr registry.

We can skip this workflow if that is case.

An additional basic docker build task which runs only on forks is added. This ensures that the image builds successfully, but we are not pushing it anywhere.

To verify the task I ran the command `docker build . --no-cache` locally and it succeeds.