### PR TITLE
Group policy controlling ICA account

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,3 +235,27 @@ chore(bump): bumping version to 2.0
 fix(bug): fixing issue with...
 feat(featurex): adding feature...
 ```
+
+### Groups
+
+```
+icad config keyring-backend test --home ./data/test-1
+icad config node tcp://localhost:16657 --home ./data/test-1
+icad config 
+
+icad tx group create-group $WALLET_1 test-metadata members.json --home ./data/test-1 --from $WALLET_1
+
+icad q group group-info 1 --home ./data/test-1
+
+icad tx group create-group-policy $WALLET_1 1 policy-meta policy.json --home ./data/test-1
+
+icad q group group-policies-by-group 1 --home ./data/test-1
+cosmos1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfwkgpd
+
+icad tx group submit-proposal proposal.json --home ./data/test-1 --from $WALLET_1
+
+icad q group proposal 1 --home ./data/test-1
+
+icad tx group vote 1 $WALLET_1 --home ./data/test-1 VOTE_OPTION_YES  meta --from $WALLET_1
+icad tx group vote 1 $WALLET_2 --home ./data/test-1 VOTE_OPTION_YES  meta --from $WALLET_2
+```

--- a/app/app.go
+++ b/app/app.go
@@ -413,7 +413,7 @@ func New(
 	)
 	icaModule := ica.NewAppModule(&app.ICAControllerKeeper, &app.ICAHostKeeper)
 
-	app.InterTxKeeper = intertxkeeper.NewKeeper(appCodec, keys[intertxtypes.StoreKey], app.ICAControllerKeeper, scopedInterTxKeeper)
+	app.InterTxKeeper = intertxkeeper.NewKeeper(appCodec, keys[intertxtypes.StoreKey], app.ICAControllerKeeper, scopedInterTxKeeper, app.GroupKeeper)
 	interTxModule := intertx.NewAppModule(appCodec, app.InterTxKeeper)
 	interTxIBCModule := intertx.NewIBCModule(app.InterTxKeeper)
 

--- a/members.json
+++ b/members.json
@@ -1,0 +1,14 @@
+{
+    "members": [
+            {
+                    "address": "cosmos1m9l358xunhhwds0568za49mzhvuxx9uxre5tud",
+                    "weight": "1",
+                    "metadata": "some metadata"
+            },
+            {
+                    "address": "cosmos10h9stc5v6ntgeygf5xf945njqq5h32r53uquvw",
+                    "weight": "1",
+                    "metadata": "some metadata"
+            }
+    ]
+}

--- a/policy.json
+++ b/policy.json
@@ -1,0 +1,8 @@
+{
+    "@type": "/cosmos.group.v1.PercentageDecisionPolicy",
+    "percentage": "1",
+    "windows": {
+        "voting_period": "1h",
+        "min_execution_period": "0s"
+    }
+}

--- a/proposal-alt.json
+++ b/proposal-alt.json
@@ -1,0 +1,25 @@
+{
+  "group_policy_address": "cosmos1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfwkgpd",
+  "messages": [
+    {
+      "@type": "/intertx.MsgSubmitTx",
+      "owner": "cosmos1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfwkgpd",
+      "connectionId": "connection-0",
+      "msg": {
+        "@type": "/cosmos.bank.v1beta1.MsgSend",
+        "from_address": "cosmos1rzxvxy6kxay5u2dnwcck8xdsx6hnv5w46ah74k3v6jnh0437qr9qf3fq82",
+        "to_address": "cosmos18pug9mrsj70pkwvgw6vhw0v8s4ufk6frnv9kdz",
+        "amount": [
+          {
+            "denom": "stake",
+            "amount": "5"
+          }
+        ]
+      }
+    }
+  ],
+  "metadata": "",
+  "proposers": [
+    "cosmos1m9l358xunhhwds0568za49mzhvuxx9uxre5tud"
+  ]
+}

--- a/proposal.json
+++ b/proposal.json
@@ -1,0 +1,13 @@
+{
+    "group_policy_address": "cosmos1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfwkgpd",
+    "messages": [
+    {
+            "@type": "/intertx.MsgRegisterAccount",
+            "owner": "cosmos1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfwkgpd",
+            "connection_id": "connection-0",
+            "version": ""
+    }
+    ],
+    "metadata": "4pIMOgIGx1vZGU=",
+    "proposers": ["cosmos1m9l358xunhhwds0568za49mzhvuxx9uxre5tud"]
+}

--- a/x/inter-tx/keeper/keeper.go
+++ b/x/inter-tx/keeper/keeper.go
@@ -22,15 +22,17 @@ type Keeper struct {
 
 	scopedKeeper        capabilitykeeper.ScopedKeeper
 	icaControllerKeeper icacontrollerkeeper.Keeper
+	groupKeeper         types.GroupKeeper
 }
 
-func NewKeeper(cdc codec.Codec, storeKey storetypes.StoreKey, iaKeeper icacontrollerkeeper.Keeper, scopedKeeper capabilitykeeper.ScopedKeeper) Keeper {
+func NewKeeper(cdc codec.Codec, storeKey storetypes.StoreKey, iaKeeper icacontrollerkeeper.Keeper, scopedKeeper capabilitykeeper.ScopedKeeper, groupKeeper types.GroupKeeper) Keeper {
 	return Keeper{
 		cdc:      cdc,
 		storeKey: storeKey,
 
 		scopedKeeper:        scopedKeeper,
 		icaControllerKeeper: iaKeeper,
+		groupKeeper:         groupKeeper,
 	}
 }
 

--- a/x/inter-tx/types/expected_keepers.go
+++ b/x/inter-tx/types/expected_keepers.go
@@ -1,0 +1,12 @@
+package types
+
+import (
+	context "context"
+
+	"github.com/cosmos/cosmos-sdk/x/group"
+)
+
+type GroupKeeper interface {
+	CreateGroup(goCtx context.Context, req *group.MsgCreateGroup) (*group.MsgCreateGroupResponse, error) // NOT USED
+	CreateGroupWithPolicy(goCtx context.Context, req *group.MsgCreateGroupWithPolicy) (*group.MsgCreateGroupWithPolicyResponse, error)
+}


### PR DESCRIPTION
Added some logic to create a group with a policy as part of `RegisterAccount`. For testing purposes.

Registering an account (don't forget to increase gas to 300K):

```
icad tx intertx register --from $WALLET_1 --connection-id connection-0 --chain-id test-1 --home ./data/test-1 --node tcp://localhost:16657 --keyring-backend test --gas 300000
```

Getting a group policy address:

```
icad q group group-policies-by-admin $WALLET_1 --home ./data/test-1 --node tcp://localhost:16657
```

Getting ICA address:

```
icad query intertx interchainaccounts connection-0 cosmos1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfwkgpd --home ./data/test-1 --node tcp://localhost:16657
```

Sending tokens to an interchain account (so it can send tokens):

```
icad tx bank send cosmos14zs2x38lmkw4eqvl3lpml5l8crzaxn6m7wuznx cosmos1rzxvxy6kxay5u2dnwcck8xdsx6hnv5w46ah74k3v6jnh0437qr9qf3fq82 100stake --node tcp://localhost:26657 --home ./data/test-2 --keyring-backend test
```

Submitting a proposal:

```
icad tx group submit-proposal proposal-alt.json --from $WALLET_1 --node http://localhost:16657 --home ./data/test-1 --keyring-backend test
```

Voting on a proposal:

```
icad tx group vote 1 $WALLET_1 VOTE_OPTION_YES "agree" --from $WALLET_1 --node http://localhost:16657 --home ./data/test-1 --keyring-backend test
```

See proposal status:

```
icad q group proposal 1 --node http://localhost:16657 --home ./data/test-1 
```

Execute a proposal:

```
icad tx group exec 1 --from $WALLET_1 --node http://localhost:16657 --home ./data/test-1 --keyring-backend test
```

Check the balance:

```
 icad q bank balances cosmos18pug9mrsj70pkwvgw6vhw0v8s4ufk6frnv9kdz --node tcp://localhost:26657 --home ./data/test-2
```