### PR TITLE
fix: wrong Amino concrete type registration

### DIFF
--- a/x/inter-tx/types/codec.go
+++ b/x/inter-tx/types/codec.go
@@ -15,8 +15,8 @@ var (
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
-	cdc.RegisterConcrete(MsgRegisterAccount{}, "intertx/MsgRegisterAccount", nil)
-	cdc.RegisterConcrete(MsgSubmitTx{}, "intertx/MsgSubmitTx", nil)
+	cdc.RegisterConcrete(&MsgRegisterAccount{}, "intertx/MsgRegisterAccount", nil)
+	cdc.RegisterConcrete(&MsgSubmitTx{}, "intertx/MsgSubmitTx", nil)
 }
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {


### PR DESCRIPTION
## Description
This PR fixes the wrong registration for the Amino types of both `MsgRegisterAccount` and `MsgSubmitTx`. 

Previously messages were registered as objects, instead of pointers. This caused them to be impossible to deserialize using the `UnmarshalJSON` method due to the following error: 

```
reflect.Set: value of type types.MsgXXXXX is not assignable to type types.Msg
```

Registering them as pointers fixes this error.