### PR TITLE
Adding missing makefile in github workflow

### DIFF
--- a/.github/workflows/build-icad-image-from-tag.yml
+++ b/.github/workflows/build-icad-image-from-tag.yml
@@ -27,8 +27,10 @@ jobs:
               registry: ${{ env.REGISTRY }}
               username: ${{ github.actor }}
               password: ${{ secrets.GITHUB_TOKEN }}
-         - name: Fetch latest Dockerfile
-           run: curl https://raw.githubusercontent.com/cosmos/interchain-accounts-demo/master/Dockerfile -o Dockerfile
+         - name: Fetch files for docker build
+           run: |
+            curl https://raw.githubusercontent.com/cosmos/interchain-accounts-demo/master/Dockerfile -o Dockerfile
+            curl https://raw.githubusercontent.com/cosmos/interchain-accounts-demo/master/Makefile -o Makefile
          - name: Build image
            run: |
             docker build . -t "${REGISTRY}/${ORG}/${IMAGE_NAME}:${VERSION}"


### PR DESCRIPTION
The build failed as the `Makefile` is also required.

I tested on this branch and the [task succeeded](https://github.com/cosmos/interchain-accounts-demo/runs/7858650888?check_suite_focus=true)