### PR TITLE
fix: change timeout offset from 1 hour to 1 minute

### DIFF
--- a/x/inter-tx/keeper/msg_server.go
+++ b/x/inter-tx/keeper/msg_server.go
@@ -65,7 +65,7 @@ func (k msgServer) SubmitTx(goCtx context.Context, msg *types.MsgSubmitTx) (*typ
 
 	// timeoutTimestamp set to max value with the unsigned bit shifted to sastisfy hermes timestamp conversion
 	// it is the responsibility of the auth module developer to ensure an appropriate timeout timestamp
-	timeoutTimestamp := ctx.BlockTime().Add(time.Hour).UnixNano()
+	timeoutTimestamp := ctx.BlockTime().Add(time.Minute).UnixNano()
 	_, err = k.icaControllerKeeper.SendTx(ctx, chanCap, msg.ConnectionId, portID, packetData, uint64(timeoutTimestamp))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I was working on an ICA test case in `ibctest` and noticed that packets were no longer timing out as expected. After digging into the issue some more I noticed that in #108 the timeout offset was changed from one minute to one hour. 