### PR TITLE
chore: log response data from 0.46 sdk

### DIFF
--- a/x/inter-tx/ibc_module.go
+++ b/x/inter-tx/ibc_module.go
@@ -7,6 +7,7 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/cosmos/interchain-accounts/x/inter-tx/keeper"
 
 	channeltypes "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
@@ -123,14 +124,16 @@ func (im IBCModule) OnAcknowledgementPacket(
 		return sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "cannot unmarshal ICS-27 packet acknowledgement: %v", err)
 	}
 
-	txMsgData := &sdk.TxMsgData{}
-	if err := proto.Unmarshal(ack.GetResult(), txMsgData); err != nil {
+	var txMsgData sdk.TxMsgData
+	if err := proto.Unmarshal(ack.GetResult(), &txMsgData); err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "cannot unmarshal ICS-27 tx message data: %v", err)
 	}
 
 	switch len(txMsgData.Data) {
 	case 0:
-		// TODO: handle for sdk 0.46.x
+		for _, msgResp := range txMsgData.GetMsgResponses() {
+			im.keeper.Logger(ctx).Info("msg response in ICS-27 packet", "response", msgResp.GoString(), "typeURL", msgResp.GetTypeUrl())
+		}
 		return nil
 	default:
 		for _, msgData := range txMsgData.Data {
@@ -175,9 +178,13 @@ func handleMsgData(ctx sdk.Context, msgData *sdk.MsgData) (string, error) {
 		}
 
 		return msgResponse.String(), nil
+	case sdk.MsgTypeURL(&stakingtypes.MsgDelegate{}):
+		msgResponse := &stakingtypes.MsgDelegateResponse{}
+		if err := proto.Unmarshal(msgData.Data, msgResponse); err != nil {
+			return "", sdkerrors.Wrapf(sdkerrors.ErrJSONUnmarshal, "cannot unmarshal delegate response message: %s", err.Error())
+		}
 
-	// TODO: handle other messages
-
+		return msgResponse.String(), nil
 	default:
 		return "", nil
 	}

--- a/x/inter-tx/keeper/keeper.go
+++ b/x/inter-tx/keeper/keeper.go
@@ -11,7 +11,6 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 
 	icacontrollerkeeper "github.com/cosmos/ibc-go/v5/modules/apps/27-interchain-accounts/controller/keeper"
-	host "github.com/cosmos/ibc-go/v5/modules/core/24-host"
 	"github.com/cosmos/interchain-accounts/x/inter-tx/types"
 )
 
@@ -36,7 +35,7 @@ func NewKeeper(cdc codec.Codec, storeKey storetypes.StoreKey, iaKeeper icacontro
 
 // Logger returns the application logger, scoped to the associated module
 func (k Keeper) Logger(ctx sdk.Context) log.Logger {
-	return ctx.Logger().With("module", fmt.Sprintf("x/%s-%s", host.ModuleName, types.ModuleName))
+	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
 }
 
 // ClaimCapability claims the channel capability passed via the OnOpenChanInit callback


### PR DESCRIPTION
- Logs the response data using the sdk v0.46 `MsgResponses` encoded Anys
- Adding the sdk v0.45 handling of `stakingtypes.MsgDelegateResponse` in `msgData.Data`

Example Logs:

- `MsgDelegateResponse`
```
{"level":"info","module":"x/intertx","response":"&Any{TypeUrl: \"/cosmos.staking.v1beta1.MsgDelegateResponse\",\n  Value: []byte(nil)\n}","typeURL":"/cosmos.staking.v1beta1.MsgDelegateResponse","time":"2022-08-22T15:15:54+02:00","message":"msg response in ICS-27 packet"}
```

- `MsgSendResponse`
```
{"level":"info","module":"x/intertx","response":"&Any{TypeUrl: \"/cosmos.bank.v1beta1.MsgSendResponse\",\n  Value: []byte(nil)\n}","typeURL":"/cosmos.bank.v1beta1.MsgSendResponse","time":"2022-08-22T15:16:01+02:00","message":"msg response in ICS-27 packet"}
```

Both response data values are `nil`, as no fields are included in either `MsgDelegateResponse` or `MsgSendResponse`.