### PR TITLE
use ctx.BlockTime() in favour of time.Now() to allow multiple nodes (…

### DIFF
--- a/x/inter-tx/keeper/msg_server.go
+++ b/x/inter-tx/keeper/msg_server.go
@@ -65,7 +65,7 @@ func (k msgServer) SubmitTx(goCtx context.Context, msg *types.MsgSubmitTx) (*typ
 
 	// timeoutTimestamp set to max value with the unsigned bit shifted to sastisfy hermes timestamp conversion
 	// it is the responsibility of the auth module developer to ensure an appropriate timeout timestamp
-	timeoutTimestamp := time.Now().Add(time.Minute).UnixNano()
+	timeoutTimestamp := ctx.BlockTime().Add(time.Hour).UnixNano()
 	_, err = k.icaControllerKeeper.SendTx(ctx, chanCap, msg.ConnectionId, portID, packetData, uint64(timeoutTimestamp))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION

cherry-pick