### PR TITLE
fix: set module version map in `InitChainer`

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -577,6 +577,8 @@ func (app *App) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci.Res
 
 	genesisState[icatypes.ModuleName] = genesisJson
 
+	app.UpgradeKeeper.SetModuleVersionMap(ctx, app.mm.GetVersionMap())
+
 	return app.mm.InitGenesis(ctx, app.appCodec, genesisState)
 }
 


### PR DESCRIPTION
Required for running upgrades in e2e.

Module version map must be set in pre-upgrade chain state.
See: https://github.com/cosmos/cosmos-sdk/blob/v0.46.1/types/module/module.go#L393-L401

Follow up tasks:
- Merge main to `release/v0.3.x`
- Tag `v0.3.5` and build docker image