### PR TITLE
chore: adding mergify.yml with backport rules

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,44 @@
+queue_rules:
+  - name: default
+    conditions:
+      - "#approved-reviews-by>=1"
+      - base=master
+      - label=automerge
+
+pull_request_rules:
+  - name: automerge to master with label automerge and branch protection passing
+    conditions:
+      - "#approved-reviews-by>=1"
+      - base=master
+      - label=automerge
+    actions:
+      queue:
+        name: default
+        method: squash
+        commit_message_template: |
+           {{ title }} (#{{ number }})
+           {{ body }}
+  - name: backport patches to v0.1.x branch (ibc-go/v3)
+    conditions:
+      - base=master
+      - label=backport-to-v0.1.x
+    actions:
+      backport:
+        branches:
+          - release/v0.1.x
+  - name: backport patches to v0.2.x branch (ibc-go/v4)
+    conditions:
+      - base=master
+      - label=backport-to-v0.2.x
+    actions:
+      backport:
+        branches:
+          - release/v0.2.x
+  - name: backport patches to v0.3.x branch (ibc-go/v5)
+    conditions:
+      - base=master
+      - label=backport-to-v0.3.x
+    actions:
+      backport:
+        branches:
+          - release/v0.3.x


### PR DESCRIPTION
## Summary 

- Adding `mergify.yml` to `.github`
- Adding backport rules for:
    - Release branch `release/v0.1.x` (ibc-go/v3)
    - Release branch `release/v0.2.x` (ibc-go/v4)
    - Release branch `release/v0.3.x` (ibc-go/v5)