### PR TITLE
fixed some bugs for go-relayer demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ make install
 make init-hermes
 
 # go relayer
-make init-golang-relayer
+make init-golang-rly
 ```
 
 :warning: **NOTE:** When you want to use both relayers interchangeably, using both of these `make` commands will set up two seperate connections (which is not needed and can lead to confusion). In the case of using both relayers, perform:
@@ -133,15 +133,15 @@ cat ./data/test-2/config/genesis.json | jq -r '.app_state.genutil.gen_txs[0].bod
 
 # Submit a staking delegation tx using the interchain account via ibc
 icad tx intertx submit \
-'{
-    "@type":"/cosmos.staking.v1beta1.MsgDelegate",
-    "delegator_address":"cosmos15ccshhmp0gsx29qpqq6g4zmltnnvgmyu9ueuadh9y2nc5zj0szls5gtddz",
-    "validator_address":"cosmosvaloper1qnk2n4nlkpw9xfqntladh74w6ujtulwnmxnh3k",
-    "amount": {
-        "denom": "stake",
-        "amount": "1000"
+"{
+    \"@type\":\"/cosmos.staking.v1beta1.MsgDelegate\",
+    \"delegator_address\": \"$ICA_ADDR\",
+    \"validator_address\":\"cosmosvaloper1qnk2n4nlkpw9xfqntladh74w6ujtulwnmxnh3k\",
+    \"amount\": {
+        \"denom\": \"stake\",
+        \"amount\": \"1000\"
     }
-}' --connection-id connection-0 --from $WALLET_1 --chain-id test-1 --home ./data/test-1 --node tcp://localhost:16657 --keyring-backend test -y
+}" --connection-id connection-0 --from $WALLET_1 --chain-id test-1 --home ./data/test-1 --node tcp://localhost:16657 --keyring-backend test -y
 
 # Alternatively provide a path to a JSON file
 icad tx intertx submit [path/to/msg.json] --connection-id connection-0 --from $WALLET_1 --chain-id test-1 --home ./data/test-1 --node tcp://localhost:16657 --keyring-backend test -y
@@ -160,17 +160,17 @@ icad q staking delegations-to cosmosvaloper1qnk2n4nlkpw9xfqntladh74w6ujtulwnmxnh
 ```bash
 # Submit a bank send tx using the interchain account via ibc
 icad tx intertx submit \
-'{
-    "@type":"/cosmos.bank.v1beta1.MsgSend",
-    "from_address":"cosmos15ccshhmp0gsx29qpqq6g4zmltnnvgmyu9ueuadh9y2nc5zj0szls5gtddz",
-    "to_address":"cosmos10h9stc5v6ntgeygf5xf945njqq5h32r53uquvw",
-    "amount": [
+"{
+    \"@type\":\"/cosmos.bank.v1beta1.MsgSend\",
+    \"from_address\": \"$ICA_ADDR\",
+    \"to_address\":\"cosmos10h9stc5v6ntgeygf5xf945njqq5h32r53uquvw\",
+    \"amount\": [
         {
-            "denom": "stake",
-            "amount": "1000"
+            \"denom\": \"stake\",
+            \"amount\": \"1000\"
         }
     ]
-}' --connection-id connection-0 --from $WALLET_1 --chain-id test-1 --home ./data/test-1 --node tcp://localhost:16657 --keyring-backend test -y
+}" --connection-id connection-0 --from $WALLET_1 --chain-id test-1 --home ./data/test-1 --node tcp://localhost:16657 --keyring-backend test -y
 
 # Alternatively provide a path to a JSON file
 icad tx intertx submit [path/to/msg.json] --connection-id connection-0 --from $WALLET_1 --chain-id test-1 --home ./data/test-1 --node tcp://localhost:16657 --keyring-backend test -y

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ https://ibc.cosmos.network/main/apps/interchain-accounts/overview.html
 1. Clone this repository and build the application binary
 
 ```bash
-git clone https://github.com/cosmos/interchain-accounts-demo.git
+git clone https://github.com/sbip-sg/interchain-accounts-demo.git
 cd interchain-accounts
 
 make install 

--- a/network/init.sh
+++ b/network/init.sh
@@ -96,4 +96,4 @@ sed -i -e 's#"tcp://0.0.0.0:1317"#"tcp://0.0.0.0:'"$RESTPORT_2"'"#g' $CHAIN_DIR/
 sed -i -e 's#":8080"#":'"$ROSETTA_2"'"#g' $CHAIN_DIR/$CHAINID_2/config/app.toml
 
 # Update host chain genesis to allow x/bank/MsgSend ICA tx execution
-sed -i -e 's/\"allow_messages\":.*/\"allow_messages\": [\"\/cosmos.bank.v1beta1.MsgSend\", \"\/cosmos.staking.v1beta1.MsgDelegate\"]/g' $CHAIN_DIR/$CHAINID_2/config/genesis.json
+sed -i -e 's/\"allow_messages\": \[/\"allow_messages\": [\"\/cosmos.bank.v1beta1.MsgSend\", \"\/cosmos.staking.v1beta1.MsgDelegate\",/g' $CHAIN_DIR/$CHAINID_2/config/genesis.json

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Store the following account addresses within the current shell env
+export WALLET_1=$(icad keys show wallet1 -a --keyring-backend test --home ./data/test-1) && echo $WALLET_1
+export WALLET_2=$(icad keys show wallet2 -a --keyring-backend test --home ./data/test-1) && echo $WALLET_2
+export WALLET_3=$(icad keys show wallet3 -a --keyring-backend test --home ./data/test-2) && echo $WALLET_3
+export WALLET_4=$(icad keys show wallet4 -a --keyring-backend test --home ./data/test-2) && echo $WALLET_4
+
+# Register an interchain account on behalf of WALLET_1 where chain test-2 is the interchain accounts host
+printf "\n== Registering interchain account.. ==\n\n"
+icad tx intertx register --from $WALLET_1 --connection-id connection-0 --chain-id test-1 --home ./data/test-1 --node tcp://localhost:16657 --keyring-backend test -y 1>/dev/null 2>&1
+
+#adjust sleep time to wait for relayer as needed
+sleep 10 
+printf "\n== Interchain account registered ==\n\n"
+
+# Query the address of the interchain account
+icad query intertx interchainaccounts connection-0 $WALLET_1 --home ./data/test-1 --node tcp://localhost:16657
+sleep 3
+# Store the interchain account address by parsing the query result: cosmos1hd0f4u7zgptymmrn55h3hy20jv2u0ctdpq23cpe8m9pas8kzd87smtf8al
+export ICA_ADDR=$(icad query intertx interchainaccounts connection-0 $WALLET_1 --home ./data/test-1 --node tcp://localhost:16657 -o json | jq -r '.interchain_account_address') && echo $ICA_ADDR
+
+# Query the interchain account balance on the host chain. It should be empty.
+icad q bank balances $ICA_ADDR --chain-id test-2 --node tcp://localhost:26657
+
+# Send funds to the interchain account.
+icad tx bank send $WALLET_3 $ICA_ADDR 10000stake --chain-id test-2 --home ./data/test-2 --node tcp://localhost:26657 --keyring-backend test -y 1>/dev/null 2>&1
+sleep 3
+printf "\n== Interchain account funded ==\n\n"
+
+# Query the balance once again and observe the changes
+icad q bank balances $ICA_ADDR --chain-id test-2 --node tcp://localhost:26657
+
+# Submit a bank send tx using the interchain account via ibc
+
+printf "\n== Submitting interchain transaction.. ==\n\n"
+
+icad tx intertx submit \
+"{
+    \"@type\":\"/cosmos.bank.v1beta1.MsgSend\",
+    \"from_address\": \"$ICA_ADDR\",
+    \"to_address\":\"cosmos10h9stc5v6ntgeygf5xf945njqq5h32r53uquvw\",
+    \"amount\": [
+        {
+            \"denom\": \"stake\",
+            \"amount\": \"1000\"
+        }
+    ]
+}" --connection-id connection-0 --from $WALLET_1 --chain-id test-1 --home ./data/test-1 --node tcp://localhost:16657 --keyring-backend test -y 1>/dev/null 2>&1
+
+# Wait until the relayer has relayed the packet, adjust as needed
+sleep 10
+printf "\n== Interchain transaction submitted ==\n\n"
+
+# Query the interchain account balance on the host chain
+icad q bank balances $ICA_ADDR --chain-id test-2 --node tcp://localhost:26657


### PR DESCRIPTION
Fixed two bugs when running the demo with go-rly:
1. Syntax error `Error: error reading GenesisDoc at data/test-2/config/genesis.json: invalid character '"' after object key:value pair` in `data/test-2/config/genesis.json` line 294 :
 ```
 "allow_messages": ["/cosmos.bank.v1beta1.MsgSend", "/cosmos.staking.v1beta1.MsgDelegate"]
            "*"
          ]
 ```
2. The ICA address in README.md file will change and should be used by environment variable `$ICA_ADDR`