### PR TITLE
fix: some bugs in go-relayer demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ make install
 make init-hermes
 
 # go relayer
-make init-golang-relayer
+make init-golang-rly
 ```
 
 :warning: **NOTE:** When you want to use both relayers interchangeably, using both of these `make` commands will set up two seperate connections (which is not needed and can lead to confusion). In the case of using both relayers, perform:
@@ -133,15 +133,15 @@ cat ./data/test-2/config/genesis.json | jq -r '.app_state.genutil.gen_txs[0].bod
 
 # Submit a staking delegation tx using the interchain account via ibc
 icad tx intertx submit \
-'{
-    "@type":"/cosmos.staking.v1beta1.MsgDelegate",
-    "delegator_address":"cosmos15ccshhmp0gsx29qpqq6g4zmltnnvgmyu9ueuadh9y2nc5zj0szls5gtddz",
-    "validator_address":"cosmosvaloper1qnk2n4nlkpw9xfqntladh74w6ujtulwnmxnh3k",
-    "amount": {
-        "denom": "stake",
-        "amount": "1000"
+"{
+    \"@type\":\"/cosmos.staking.v1beta1.MsgDelegate\",
+    \"delegator_address\": \"$ICA_ADDR\",
+    \"validator_address\":\"cosmosvaloper1qnk2n4nlkpw9xfqntladh74w6ujtulwnmxnh3k\",
+    \"amount\": {
+        \"denom\": \"stake\",
+        \"amount\": \"1000\"
     }
-}' --connection-id connection-0 --from $WALLET_1 --chain-id test-1 --home ./data/test-1 --node tcp://localhost:16657 --keyring-backend test -y
+}" --connection-id connection-0 --from $WALLET_1 --chain-id test-1 --home ./data/test-1 --node tcp://localhost:16657 --keyring-backend test -y
 
 # Alternatively provide a path to a JSON file
 icad tx intertx submit [path/to/msg.json] --connection-id connection-0 --from $WALLET_1 --chain-id test-1 --home ./data/test-1 --node tcp://localhost:16657 --keyring-backend test -y
@@ -160,17 +160,17 @@ icad q staking delegations-to cosmosvaloper1qnk2n4nlkpw9xfqntladh74w6ujtulwnmxnh
 ```bash
 # Submit a bank send tx using the interchain account via ibc
 icad tx intertx submit \
-'{
-    "@type":"/cosmos.bank.v1beta1.MsgSend",
-    "from_address":"cosmos15ccshhmp0gsx29qpqq6g4zmltnnvgmyu9ueuadh9y2nc5zj0szls5gtddz",
-    "to_address":"cosmos10h9stc5v6ntgeygf5xf945njqq5h32r53uquvw",
-    "amount": [
+"{
+    \"@type\":\"/cosmos.bank.v1beta1.MsgSend\",
+    \"from_address\": \"$ICA_ADDR\",
+    \"to_address\":\"cosmos10h9stc5v6ntgeygf5xf945njqq5h32r53uquvw\",
+    \"amount\": [
         {
-            "denom": "stake",
-            "amount": "1000"
+            \"denom\": \"stake\",
+            \"amount\": \"1000\"
         }
     ]
-}' --connection-id connection-0 --from $WALLET_1 --chain-id test-1 --home ./data/test-1 --node tcp://localhost:16657 --keyring-backend test -y
+}" --connection-id connection-0 --from $WALLET_1 --chain-id test-1 --home ./data/test-1 --node tcp://localhost:16657 --keyring-backend test -y
 
 # Alternatively provide a path to a JSON file
 icad tx intertx submit [path/to/msg.json] --connection-id connection-0 --from $WALLET_1 --chain-id test-1 --home ./data/test-1 --node tcp://localhost:16657 --keyring-backend test -y

--- a/network/init.sh
+++ b/network/init.sh
@@ -96,4 +96,4 @@ sed -i -e 's#"tcp://0.0.0.0:1317"#"tcp://0.0.0.0:'"$RESTPORT_2"'"#g' $CHAIN_DIR/
 sed -i -e 's#":8080"#":'"$ROSETTA_2"'"#g' $CHAIN_DIR/$CHAINID_2/config/app.toml
 
 # Update host chain genesis to allow x/bank/MsgSend ICA tx execution
-sed -i -e 's/\"allow_messages\":.*/\"allow_messages\": [\"\/cosmos.bank.v1beta1.MsgSend\", \"\/cosmos.staking.v1beta1.MsgDelegate\"]/g' $CHAIN_DIR/$CHAINID_2/config/genesis.json
+sed -i -e 's/\"allow_messages\": \[/\"allow_messages\": [\"\/cosmos.bank.v1beta1.MsgSend\", \"\/cosmos.staking.v1beta1.MsgDelegate\",/g' $CHAIN_DIR/$CHAINID_2/config/genesis.json


### PR DESCRIPTION
Fixed two bugs when running the demo with go-rly:
1. Syntax error `Error: error reading GenesisDoc at data/test-2/config/genesis.json: invalid character '"' after object key:value pair` in `data/test-2/config/genesis.json` line 294 :
 ```
 "allow_messages": ["/cosmos.bank.v1beta1.MsgSend", "/cosmos.staking.v1beta1.MsgDelegate"]
            "*"
          ]
 ```
The cause is `sed` usage https://github.com/cosmos/interchain-accounts-demo/blob/3dbc8dce2b6238d7bfa9edef4c31a6665a0dde5f/network/init.sh#L99
2. The ICA address in README.md file will change and should be used by environment variable `$ICA_ADDR`